### PR TITLE
Fix Travis FTBFS due to OpenMP atomic capture

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: c
 sudo: required
+dist: trusty
 
 install:
-  - sudo apt-get install gfortran libhdf5-serial-dev
+  - sudo apt-get install -y gfortran libhdf5-serial-dev
 
 script:
   - mkdir build && cd build

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ global variables, enable testing and plan for parallel accelerations.
 
 RMPCDMD has the following requirements:
 
-- A Fortran 2003 compiler (e.g. [gfortran](https://gcc.gnu.org/wiki/GFortran))
+- A Fortran 2003 compiler (e.g. [gfortran](https://gcc.gnu.org/wiki/GFortran) ≥ 4.7 with support for [OpenMP](https://gcc.gnu.org/wiki/openmp) ≥ 3.1)
 - A Fortran enabled [HDF5](https://www.hdfgroup.org/HDF5/) installation
 - [CMake](http://cmake.org/)
 - [GNU Make](https://www.gnu.org/software/make/)


### PR DESCRIPTION
`omp atomic capture` was added in OpenMP 3.1, which is implemented by gfortran 4.7 and later.
